### PR TITLE
#172 Временно исправить docker-compose для работы заказчика

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -7,6 +7,8 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
     restart: unless-stopped
     env_file:
       - server/.env
@@ -34,7 +36,7 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "8081:8080"
     networks:
       - frontend
 


### PR DESCRIPTION
resolves #172
Исправлен докер компоуз таким образом, чтобы у заказчика была возможность отправить события с запущенного локально вне сети мудла moevm. 