### PR TITLE
#192 - Убрать строгую типизацию категорий элементов и действий 

### DIFF
--- a/server/src/models/session_data.py
+++ b/server/src/models/session_data.py
@@ -2,43 +2,15 @@ import uuid
 from pydantic import BaseModel, EmailStr, HttpUrl, Field
 from datetime import datetime
 from typing import List
-from enum import Enum
-
-
-class ElementTypeEnum(str, Enum):
-    button = "button"
-    page = "page"
-
-    def __str__(self):
-        return self.value
-
-
-class ActionTypeEnum(str, Enum):
-    conversation = "conversation"
-    visible = "visible"
-    hidden = "hidden"
-
-    def __str__(self):
-        return self.value
-
-
-class EventTypeEnum(str, Enum):
-    mousedown = "mousedown"
-    visibilitychange = "visibilitychange"
-    copy = "copy"
-    paste = "paste"
-
-    def __str__(self):
-        return self.value
 
 
 class Payload(BaseModel):
     timestamp: datetime = Field(default_factory=lambda: datetime.now().isoformat())
     page: HttpUrl = Field(...)
-    element_type: ElementTypeEnum = Field(...)
+    element_type: str = Field(...)
     element_name: str = Field(...)
-    action_type: ActionTypeEnum = Field(...)
-    event_type: EventTypeEnum = Field(...)
+    action_type: str = Field(...)
+    event_type: str = Field(...)
     element_html: str = Field(..., description="The HTML content of the element")
 
     class Config:

--- a/stat_tracker/moodle_stat_tracker.html
+++ b/stat_tracker/moodle_stat_tracker.html
@@ -140,7 +140,8 @@
                 element_type: element_type,
                 element_name: name,
                 action_type: type,
-                event_type: e.type
+                event_type: e.type, 
+                element_html: ' ' // TODO: replace with rea; element_html
             }
             interactor.records.push(trackingEntity);
 


### PR DESCRIPTION
Убрана строгая типизация
Для проверки того, что корректно собираются все типы действий необходимо было добавить в текущий скрипт отправку значения в поле "html_element", поэтому добавила это поле в stat_tracker.
Далее в рамках соответствующей задачи необходимо будет заменить на функцию, которая собирается html элемента. 