### PR TITLE
#207 Healthcheck endpoint 

### DIFF
--- a/server/src/api/api.py
+++ b/server/src/api/api.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter
-
-from src.api.endpoints import statistics, user, authorization
+from src.api.endpoints import statistics, user, authorization, healthcheck
 
 api_router = APIRouter()
 api_router.include_router(statistics.router, prefix="/statistics", tags=["statistics"])
 api_router.include_router(user.router, prefix="/user", tags=["user"])
 api_router.include_router(authorization.router, prefix="/auth", tags=["authorization"])
+api_router.include_router(healthcheck.router, prefix="/healthcheck", tags=["healthcheck"])

--- a/server/src/api/endpoints/healthcheck.py
+++ b/server/src/api/endpoints/healthcheck.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, HTTPException
+from starlette import status
+
+from src.depends import client
+
+router = APIRouter()
+
+
+@router.get(
+    "/",
+    status_code=status.HTTP_200_OK,
+    response_description="Healthcheck ping",
+    response_model_by_alias=False
+)
+async def healthcheck():
+    try:
+        return await client["moodle-statistics"].command("ping")
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail={"message": "Database instance is unhealthy", "error": str(e)})


### PR DESCRIPTION
Fixes #207

Добавил endpoint, который позволяет проверять здоровье backend. При GET-запросе на этот эндпоинт, пингуется БД. В случае, если отвалилась БД, вернется 500 код ошибки, а также соответствующее сообщение с проблемой. 
Пример при стуке в ручку с лежащей базой:
```json
{
  "detail": {
    "message": "Database instance is unhealthy",
    "error": "mongodb:27017: [Errno -3] Try again (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms), Timeout: 30s, Topology Description: <TopologyDescription id: 663bd89dc2c0a79ff1b82f35, topology_type: Single, servers: [<ServerDescription ('mongodb', 27017) server_type: Unknown, rtt: None, error=AutoReconnect('mongodb:27017: [Errno -3] Try again (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms)')>]>"
  }
}
```
Пример со здоровой БД (код 200):
```json
{
  "ok": 1
}
```