### PR TITLE
#186 Тест при подключении скрипта

### DIFF
--- a/server/src/api/endpoints/healthcheck.py
+++ b/server/src/api/endpoints/healthcheck.py
@@ -1,3 +1,4 @@
+import pymongo
 from fastapi import APIRouter, HTTPException
 from starlette import status
 
@@ -14,6 +15,7 @@ router = APIRouter()
 )
 async def healthcheck():
     try:
-        return await client["moodle-statistics"].command("ping").maxTimeMS(5000)
+        with pymongo.timeout(5):
+            return await client["moodle-statistics"].command("ping")
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail={"message": "Database instance is unhealthy", "error": str(e)})

--- a/server/src/api/endpoints/healthcheck.py
+++ b/server/src/api/endpoints/healthcheck.py
@@ -14,6 +14,6 @@ router = APIRouter()
 )
 async def healthcheck():
     try:
-        return await client["moodle-statistics"].command("ping")
+        return await client["moodle-statistics"].command("ping").maxTimeMS(5000)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail={"message": "Database instance is unhealthy", "error": str(e)})

--- a/stat_tracker/moodle_stat_tracker.html
+++ b/stat_tracker/moodle_stat_tracker.html
@@ -255,7 +255,9 @@
 
 
 <script type="module">
-    var interactions = new Interactor({
+
+    function initTracker(){
+        var interactions = new Interactor({
         trackAll: false,
         numberActionsToSend: 5,
         trackPagePresence: true,
@@ -269,4 +271,38 @@
         async: true,
         debug: true
     });
+    }
+
+    async function healthCheck(retries){
+        const apiHealthCheck = "http://localhost:8080/api/healthcheck"
+        try{
+            let response = await fetch(apiHealthCheck);
+            if (!response.ok){
+                console.log('Во время подключения произошла ошибка. Данные могут быть не записаны.');
+                if(retries > 0){
+                    console.log(`Повторное подключение. Осталось попыток: ${retries-1}`)
+                    await new Promise(resolve => setTimeout(resolve, 20000));
+                    await healthCheck(retries - 1)
+                }else{
+                    console.log("Попытки подключения исчерпаны. Moodle работает без сбора статистики.")
+                }
+            }
+            else {
+                console.log("Скрипт подключен успешно. Соединение с сервером установлено.");
+                initTracker();
+            }
+        } catch(error){
+            console.log('Во время подключения произошла ошибка. Данные могут быть не записаны.');
+            if(retries > 0){
+                    console.log(`Повторное подключение. Осталось попыток: ${retries-1}`)
+                    await new Promise(resolve => setTimeout(resolve, 20000));
+                    await healthCheck(retries - 1)
+                }else{
+                    console.log("Попытки подключения исчерпаны. Moodle работает без сбора статистики.")
+                }
+        }
+    }
+
+    healthCheck(3)
+
 </script>

--- a/stat_tracker/moodle_stat_tracker.html
+++ b/stat_tracker/moodle_stat_tracker.html
@@ -281,7 +281,7 @@
                 console.log('Во время подключения произошла ошибка. Данные могут быть не записаны.');
                 if(retries > 0){
                     console.log(`Повторное подключение. Осталось попыток: ${retries-1}`)
-                    await new Promise(resolve => setTimeout(resolve, 20000));
+                    await new Promise(resolve => setTimeout(resolve, 5000));
                     await healthCheck(retries - 1)
                 }else{
                     console.log("Попытки подключения исчерпаны. Moodle работает без сбора статистики.")
@@ -295,7 +295,7 @@
             console.log('Во время подключения произошла ошибка. Данные могут быть не записаны.');
             if(retries > 0){
                     console.log(`Повторное подключение. Осталось попыток: ${retries-1}`)
-                    await new Promise(resolve => setTimeout(resolve, 20000));
+                    await new Promise(resolve => setTimeout(resolve, 5000));
                     await healthCheck(retries - 1)
                 }else{
                     console.log("Попытки подключения исчерпаны. Moodle работает без сбора статистики.")


### PR DESCRIPTION
Добавлена проверка работоспособности сервера и базы данных при подключении скрипта.
Инициализация трекера происходит только при успешной проверке.
Количество повторных попыток подключения указывается в вызове функции healthCheck().
При исчерпании попыток подключения мудл работает в штатном режиме, как будто скрипт не подключался.

resolves #186 