### PR TITLE
#187 Добавить сбор html кода элемента

### DIFF
--- a/stat_tracker/moodle_stat_tracker.html
+++ b/stat_tracker/moodle_stat_tracker.html
@@ -165,7 +165,7 @@
                 element_name: name,
                 action_type: type,
                 event_type: e.type,
-                element_html: ' ' // TODO: make  a real function to collect element_html
+                element_html: `${e.target.outerHTML}`
             }
             interactor.records.push(trackingEntity);
 


### PR DESCRIPTION
В отправляемые данные добавлен html-код элемента, с которым взаимодействовал пользователь.
По идее, поле с html у элемента изначально хранится в виде строки, но, чтобы наверняка, я его еще раз скастил к строке.

resolves #187 